### PR TITLE
spec update

### DIFF
--- a/aws/resolve_customer/package/python-resolve_customer-spec-template
+++ b/aws/resolve_customer/package/python-resolve_customer-spec-template
@@ -18,17 +18,12 @@
 # If they aren't provided by a system installed macro, define them
 %{!?_defaultdocdir: %global _defaultdocdir %{_datadir}/doc}
 
-%if 0%{?suse_version} && 0%{?suse_version} < 1600
-%global __python3 /usr/bin/python3.11
-%global python3_pkgversion 311
+%if 0%{?suse_version} >= 1600
+%define pythons %{primary_python}
 %else
-%{!?__python3: %global __python3 /usr/bin/python3}
-%{!?python3_pkgversion:%global python3_pkgversion 3}
+%define pythons python311
 %endif
-
-%if %{undefined python3_sitelib}
-%global python3_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
-%endif 
+%global _sitelibdir %{%{pythons}_sitelib}
 
 %global pygroup Development/Languages/Python
 %global sysgroup System/Management
@@ -43,24 +38,25 @@ Url:            https://github.com/SUSE-Enceladus/suse-saas-tools
 Group:          %{pygroup}
 Source:         %{name}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-BuildRequires:  python%{python3_pkgversion}-%{develsuffix} >= 3.9
-BuildRequires:  python%{python3_pkgversion}-build
-BuildRequires:  python%{python3_pkgversion}-installer
-BuildRequires:  python%{python3_pkgversion}-poetry-core >= 1.2.0
-BuildRequires:  python%{python3_pkgversion}-wheel
-BuildRequires:  python%{python3_pkgversion}-requests
-BuildRequires:  python%{python3_pkgversion}-setuptools
+BuildRequires:  %{pythons}-%{develsuffix} >= 3.9
+BuildRequires:  %{pythons}-build
+BuildRequires:  %{pythons}-installer
+BuildRequires:  %{pythons}-poetry-core >= 1.2.0
+BuildRequires:  %{pythons}-wheel
+BuildRequires:  %{pythons}-requests
+BuildRequires:  %{pythons}-setuptools
 
 %description
 SaaS tooling for the pubcloud team.
 
 # python3xx-resolve_customer
-%package -n python%{python3_pkgversion}-resolve_customer
+%package -n %{pythons}-resolve_customer
 Summary:        resolve_customer - AWS ResolveCustomer
 Group:          %{pygroup}
-Requires:       python%{python3_pkgversion} >= 3.11
-Requires:       python%{python3_pkgversion}-requests
-Requires:       python%{python3_pkgversion}-setuptools
+Requires:      python >= 3.11
+Requires:      %{pythons}-boto3
+Requires:      %{pythons}-requests
+Requires:      %{pythons}-setuptools
 
 %description -n python%{python3_pkgversion}-resolve_customer
 SaaS tooling for the pubcloud team.
@@ -68,15 +64,13 @@ SaaS tooling for the pubcloud team.
 %prep
 %autosetup -n resolve_customer-%{version}
 
-# Build application wheel
-%{__python3} -m build --no-isolation --wheel
-
 %build
+%pyproject_wheel
 
 %install
-%{__python3} -m installer --destdir %{buildroot} %{?is_deb:--no-compile-bytecode} dist/*.whl
+%pyproject_install
 
-%files -n python%{python3_pkgversion}-resolve_customer
-%{python3_sitelib}/resolve_customer*
+%files -n %{pythons}-resolve_customer
+%{_sitelibdir}/resolve_customer*
 
 %changelog

--- a/aws/sqs_event_manager/package/python-sqs_event_manager-spec-template
+++ b/aws/sqs_event_manager/package/python-sqs_event_manager-spec-template
@@ -18,17 +18,12 @@
 # If they aren't provided by a system installed macro, define them
 %{!?_defaultdocdir: %global _defaultdocdir %{_datadir}/doc}
 
-%if 0%{?suse_version} && 0%{?suse_version} < 1600
-%global __python3 /usr/bin/python3.11
-%global python3_pkgversion 311
+%if 0%{?suse_version} >= 1600
+%define pythons %{primary_python}
 %else
-%{!?__python3: %global __python3 /usr/bin/python3}
-%{!?python3_pkgversion:%global python3_pkgversion 3}
+%define pythons python311
 %endif
-
-%if %{undefined python3_sitelib}
-%global python3_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
-%endif 
+%global _sitelibdir %{%{pythons}_sitelib}
 
 %global pygroup Development/Languages/Python
 %global sysgroup System/Management
@@ -43,24 +38,25 @@ Url:            https://github.com/SUSE-Enceladus/suse-saas-tools
 Group:          %{pygroup}
 Source:         %{name}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-BuildRequires:  python%{python3_pkgversion}-%{develsuffix} >= 3.9
-BuildRequires:  python%{python3_pkgversion}-build
-BuildRequires:  python%{python3_pkgversion}-installer
-BuildRequires:  python%{python3_pkgversion}-poetry-core >= 1.2.0
-BuildRequires:  python%{python3_pkgversion}-wheel
-BuildRequires:  python%{python3_pkgversion}-requests
-BuildRequires:  python%{python3_pkgversion}-setuptools
+BuildRequires:  %{pythons}-%{develsuffix} >= 3.9
+BuildRequires:  %{pythons}-build
+BuildRequires:  %{pythons}-installer
+BuildRequires:  %{pythons}-poetry-core >= 1.2.0
+BuildRequires:  %{pythons}-wheel
+BuildRequires:  %{pythons}-requests
+BuildRequires:  %{pythons}-setuptools
 
 %description
 SaaS tooling for the pubcloud team.
 
 # python3xx-sqs_event_manager
-%package -n python%{python3_pkgversion}-sqs_event_manager
+%package -n %{pythons}-sqs_event_manager
 Summary:        sqs_event_manager - AWS Lambda
 Group:          %{pygroup}
-Requires:       python%{python3_pkgversion} >= 3.11
-Requires:       python%{python3_pkgversion}-requests
-Requires:       python%{python3_pkgversion}-setuptools
+Requires:       python >= 3.11
+Requires:       %{pythons}-boto3
+Requires:       %{pythons}-requests
+Requires:       %{pythons}-setuptools
 
 %description -n python%{python3_pkgversion}-sqs_event_manager
 SaaS tooling for the pubcloud team.
@@ -68,15 +64,13 @@ SaaS tooling for the pubcloud team.
 %prep
 %autosetup -n sqs_event_manager-%{version}
 
-# Build application wheel
-%{__python3} -m build --no-isolation --wheel
-
 %build
+%pyproject_wheel
 
 %install
-%{__python3} -m installer --destdir %{buildroot} %{?is_deb:--no-compile-bytecode} dist/*.whl
+%pyproject_install
 
-%files -n python%{python3_pkgversion}-sqs_event_manager
-%{python3_sitelib}/sqs_event_manager*
+%files -n %{pythons}-sqs_event_manager
+%{_sitelibdir}/sqs_event_manager*
 
 %changelog


### PR DESCRIPTION
Use our established convention for different Python version builds. We only want to build against one interpreter in any given distribution. For older distros (SLE & openSUSE Leap 15.x) we specify the interpreter we want. Use the build service macros as they will take care of pointing the #! to the correct interpreter.