### PR TITLE
Include the necessary RPM macros package for building

### DIFF
--- a/aws/resolve_customer/package/python-resolve_customer-spec-template
+++ b/aws/resolve_customer/package/python-resolve_customer-spec-template
@@ -45,6 +45,7 @@ BuildRequires:  %{pythons}-poetry-core >= 1.2.0
 BuildRequires:  %{pythons}-wheel
 BuildRequires:  %{pythons}-requests
 BuildRequires:  %{pythons}-setuptools
+BuildRequires:  python-rpm-macros
 
 %description
 SaaS tooling for the pubcloud team.
@@ -53,7 +54,7 @@ SaaS tooling for the pubcloud team.
 %package -n %{pythons}-resolve_customer
 Summary:        resolve_customer - AWS ResolveCustomer
 Group:          %{pygroup}
-Requires:      python >= 3.11
+Requires:      python3 >= 3.11
 Requires:      %{pythons}-boto3
 Requires:      %{pythons}-requests
 Requires:      %{pythons}-setuptools

--- a/aws/sqs_event_manager/package/python-sqs_event_manager-spec-template
+++ b/aws/sqs_event_manager/package/python-sqs_event_manager-spec-template
@@ -46,6 +46,7 @@ BuildRequires:  %{pythons}-poetry-core >= 1.2.0
 BuildRequires:  %{pythons}-wheel
 BuildRequires:  %{pythons}-requests
 BuildRequires:  %{pythons}-setuptools
+BuildRequires:  python-rpm-macros
 
 %description
 SaaS tooling for the pubcloud team.


### PR DESCRIPTION
We need to explicitly include the RPM macros package for Python builds and not depend on other packages to pull the macro into the build environment.