### PR TITLE
Start implementation of sqs event manager

### DIFF
--- a/aws/sqs_event_manager/app_sqs_event_manager.py
+++ b/aws/sqs_event_manager/app_sqs_event_manager.py
@@ -1,0 +1,6 @@
+#!/usr/bin/python3
+from sqs_event_manager.app import lambda_handler as sqs_event_manager_lambda
+
+
+def lambda_handler(event, context):
+    return sqs_event_manager_lambda(event, context)

--- a/aws/sqs_event_manager/package/python-sqs_event_manager-spec-template
+++ b/aws/sqs_event_manager/package/python-sqs_event_manager-spec-template
@@ -26,11 +26,13 @@ Group:          %{pygroup}
 Source:         %{name}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Requires:       python3 >= 3.11
+Requires:       %{python_module resolve_customer}
 BuildRequires:  python3 >= 3.11
 BuildRequires:  %{python_module devel}
 BuildRequires:  %{python_module setuptools}
 BuildRequires:  %{python_module pip}
 BuildRequires:  %{python_module poetry}
+BuildRequires:  %{python_module resolve_customer}
 BuildRequires:  fdupes
 BuildRequires:  python-rpm-macros
 %python_subpackages

--- a/aws/sqs_event_manager/pyproject.toml
+++ b/aws/sqs_event_manager/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 python = "^3.11"
 requests = ">=2.25.0"
 setuptools = ">=50"
-boto3 = ">=1.12"
+resolve_customer = { git = "https://github.com/SUSE-Enceladus/suse-saas-tools.git", subdirectory = "aws/resolve_customer", branch = "main" }
 
 [tool.poetry.scripts]
 # call scripts might be not needed, but just to show how

--- a/aws/sqs_event_manager/pyproject.toml
+++ b/aws/sqs_event_manager/pyproject.toml
@@ -42,6 +42,7 @@ classifiers = [
 python = "^3.11"
 requests = ">=2.25.0"
 setuptools = ">=50"
+boto3 = ">=1.12"
 
 [tool.poetry.scripts]
 # call scripts might be not needed, but just to show how

--- a/aws/sqs_event_manager/pyproject.toml
+++ b/aws/sqs_event_manager/pyproject.toml
@@ -20,6 +20,7 @@ packages = [
 ]
 
 include = [
+   { path = "app_sqs_event_manager.py", format = "sdist" },
    { path = ".bumpversion.cfg", format = "sdist" },
    { path = ".coverage*", format = "sdist" },
    { path = "package", format = "sdist" },

--- a/aws/sqs_event_manager/sqs_event_manager/app.py
+++ b/aws/sqs_event_manager/sqs_event_manager/app.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2025 SUSE LLC.  All rights reserved.
+#
+# This file is part of suse-saas-tools
+#
+# suse-saas-tools is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+"""
+Lambda to handle SQS messages from from
+AWS Metering/Entitlement Marketplace API's
+"""
+import json
+import logging
+
+from sqs_event_manager.queue import delete_message
+from sqs_event_manager.message import AWSSNSMessage
+
+logger = logging.getLogger()
+
+
+def lambda_handler(event, context):
+    """
+    Expects event type matching the SNS topic
+
+    {
+        'Records': [
+            {
+                'message_id': 'str',
+                'receipt_handle': 'str',
+                'body': {
+                    'Type' : 'str',
+                    'MessageId : 'str',
+                    'TopicArn' : 'str',
+                    'Message' : {
+                        'action': 'str',
+                        'customer-identifier': 'str',
+                        'product-code': 'str',
+                    },
+                    'Timestamp' : 'str',
+                    'SignatureVersion' : 'str',
+                    'Signature' : 'str',
+                    'SigningCertURL' : 'str',
+                    'UnsubscribeURL' : 'str'
+                },
+                'attributes': {
+                    'ApproximateReceiveCount': 'str',
+                    'SentTimestamp': 'str',
+                    'SenderId': 'str',
+                    'ApproximateFirstReceiveTimestamp': 'str'
+                },
+                'messageAttributes': {},
+                'md5OfBody': 'str',
+                'eventSource': 'aws:sqs',
+                'eventSourceARN': 'arn:aws:sqs:us-east-1:111122223333:my-queue',
+                'awsRegion': 'us-east-1'
+            }
+        ]
+    }
+    """
+    batch_item_failures = []
+    sqs_batch_response = {}
+
+    try:
+        for message in event['Records']:
+            process_message(message, batch_item_failures)
+    except Exception as error:
+        return json.dumps(
+            error_response(500, f'{type(error).__name__}: {error}')
+        )
+
+    sqs_batch_response['batchItemFailures'] = batch_item_failures
+    return json.dumps(sqs_batch_response)
+
+
+def process_message(record: dict, batch_item_failures: dict):
+    """
+    Handle message received from SQS queue
+
+    Ensure the message is proper format. Get the customer entitlements and
+    send the information to the SCC service.
+    """
+    try:
+        message = AWSSNSMessage(record)
+
+        if not message.action:
+            logger.info(f'Received an unknown message: {json.dumps(record)}')
+        elif message.action == 'entitlement-updated':
+            # Do we notify SCC to resolve customer API or do that here and
+            # send an update to SCC?
+            logger.debug(
+                f'Entitlements updated for customer: {message.customer_id}'
+            )
+        else:
+            logger.info(f'Received a message with an unhandled action type: {message.action}')
+
+        # Always clean up message except on failure
+        delete_message(message.event_source_arn, message.receipt_handle)
+    except Exception as error:
+        logger.exception(f'Exception processing message {message.receipt_handle}: {error}')
+        batch_item_failures.append({'itemIdentifier': message.message_id})
+
+
+def error_response(status_code: int, message: str) -> dict:
+    return {
+        'isBase64Encoded': False,
+        'statusCode': status_code,
+        'body': message
+    }

--- a/aws/sqs_event_manager/sqs_event_manager/app.py
+++ b/aws/sqs_event_manager/sqs_event_manager/app.py
@@ -25,7 +25,8 @@ import logging
 from sqs_event_manager.queue import delete_message
 from sqs_event_manager.message import AWSSNSMessage
 
-logger = logging.getLogger()
+logger = logging.getLogger('sqs_event_manager')
+logger.setLevel('INFO')
 
 
 def lambda_handler(event, context):
@@ -97,7 +98,7 @@ def process_message(record: dict, batch_item_failures: dict):
         elif message.action == 'entitlement-updated':
             # Do we notify SCC to resolve customer API or do that here and
             # send an update to SCC?
-            logger.debug(
+            logger.info(
                 f'Entitlements updated for customer: {message.customer_id}'
             )
         else:
@@ -106,7 +107,7 @@ def process_message(record: dict, batch_item_failures: dict):
         # Always clean up message except on failure
         delete_message(message.event_source_arn, message.receipt_handle)
     except Exception as error:
-        logger.exception(f'Exception processing message {message.receipt_handle}: {error}')
+        logger.error(f'Exception processing message {message.receipt_handle}: {error}')
         batch_item_failures.append({'itemIdentifier': message.message_id})
 
 

--- a/aws/sqs_event_manager/sqs_event_manager/message.py
+++ b/aws/sqs_event_manager/sqs_event_manager/message.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2025 SUSE LLC.  All rights reserved.
+#
+# This file is part of suse-saas-tools
+#
+# suse-saas-tools is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+import logging
+
+logger = logging.getLogger()
+
+
+class AWSSNSMessage:
+    def __init__(self, message: dict):
+        self.message = message
+
+    def get_body(self) -> str:
+        return self.__get('body')
+
+    def get_sns_content(self) -> str:
+        return self.get_body()['Message'] or {}
+
+    @property
+    def message_id(self) -> str:
+        return self.__get('message_id')
+
+    @property
+    def customer_id(self) -> str:
+        return self.get_sns_content()['customer-identifier']
+
+    @property
+    def product_code(self) -> str:
+        return self.get_sns_content()['product-code']
+
+    @property
+    def action(self) -> str:
+        return self.get_sns_content()['action']
+
+    @property
+    def event_source_arn(self) -> str:
+        return self.__get('eventSourceARN')
+
+    @property
+    def receipt_handle(self) -> str:
+        return self.__get('receipt_handle')
+
+    def __get(self, key) -> str:
+        return self.message[key] if self.message else ''

--- a/aws/sqs_event_manager/sqs_event_manager/message.py
+++ b/aws/sqs_event_manager/sqs_event_manager/message.py
@@ -17,7 +17,8 @@
 #
 import logging
 
-logger = logging.getLogger()
+logger = logging.getLogger('sqs_event_manager')
+logger.setLevel('INFO')
 
 
 class AWSSNSMessage:

--- a/aws/sqs_event_manager/sqs_event_manager/queue.py
+++ b/aws/sqs_event_manager/sqs_event_manager/queue.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2025 SUSE LLC.  All rights reserved.
+#
+# This file is part of suse-saas-tools
+#
+# suse-saas-tools is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import boto3
+
+
+def get_queue_url(arn: str) -> str:
+    """Return queue url based on arn"""
+    prefix, region, account, queue = arn.rsplit(':', maxsplit=3)
+    return f'https://sqs.{region}.amazonaws.com/{account}/{queue}'
+
+
+def delete_message(queue_arn: str, receipt_handle: str):
+    """Delete the message from the queue"""
+    queue_url = get_queue_url(queue_arn)
+    client = boto3.client('sqs')
+
+    client.delete_message(
+        QueueUrl=queue_url,
+        ReceiptHandle=receipt_handle
+    )

--- a/aws/sqs_event_manager/test/unit/app_test.py
+++ b/aws/sqs_event_manager/test/unit/app_test.py
@@ -1,0 +1,92 @@
+import logging
+
+from unittest.mock import (
+    Mock, patch
+)
+
+from sqs_event_manager.app import (
+    lambda_handler, process_message
+)
+from pytest import fixture
+
+record = {
+    'message_id': '123',
+    'receipt_handle': 'abc123',
+    'body': {
+        'Type': 'Notification',
+        'MessageId': '6f4eae69-8205-5531-84f7-f1b478aeb04',
+        'TopicArn': 'arn:aws:sns:us-east-1:XXX:aws-mp-entitlement-notification-XXX',
+        'Message': {
+            'action': 'entitlement-updated',
+            'customer-identifier': 'abc123',
+            'product-code': '7hn1uo40wt6psy10ovxyh4zzn',
+        },
+        'Timestamp': '2025-01-15 16:31:50',
+        'SignatureVersion': '1',
+        'Signature': 'signature',
+        'SigningCertURL': 'https://cert.com',
+        'UnsubscribeURL': 'https://unsub.com'
+    },
+    'attributes': {
+        'ApproximateReceiveCount': '1',
+        'SentTimestamp': '1545082649183',
+        'SenderId': 'abc123',
+        'ApproximateFirstReceiveTimestamp': '1545082649185'
+    },
+    'messageAttributes': {},
+    'md5OfBody': 'md5hash',
+    'eventSource': 'aws:sqs',
+    'eventSourceARN': 'arn:aws:sqs:us-east-1:111122223333:my-queue',
+    'awsRegion': 'us-east-1'
+}
+
+
+class TestApp:
+    @fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        self._caplog = caplog
+
+    def test_lambda_handler_invalid_event(self):
+        assert lambda_handler(event={'some': 'some'}, context=Mock()) == \
+            '{\"isBase64Encoded\": false, \"statusCode\": 500, ' \
+            '\"body\": \"KeyError: \'Records\'\"}'
+
+    @patch('sqs_event_manager.app.AWSCustomerEntitlement')
+    @patch('sqs_event_manager.app.process_message')
+    def test_lambda_handler(
+        self, mock_process_message, mock_AWSCustomerEntitlement
+    ):
+        mock_process_message.return_value = {}
+        entitlements = Mock()
+        mock_AWSCustomerEntitlement.return_value = entitlements
+
+        lambda_handler(
+            event={'Records': [record]},
+            context=Mock()
+        )
+        mock_process_message.assert_called_once_with(
+            record,
+            []
+        )
+
+    @patch('sqs_event_manager.app.AWSCustomerEntitlement')
+    @patch('sqs_event_manager.app.delete_message')
+    def test_process_message(
+        self, mock_delete_message, mock_AWSCustomerEntitlement
+    ):
+        entitlements = Mock()
+        mock_AWSCustomerEntitlement.return_value = entitlements
+
+        batch_item_failures = []
+        process_message(record, batch_item_failures)
+        assert len(batch_item_failures) == 0
+
+        record['body']['Message']['action'] = None
+        with self._caplog.at_level(logging.INFO):
+            process_message(record, batch_item_failures)
+            assert 'Received an unknown message:' in self._caplog.text
+
+        record['body']['Message']['action'] = 'fake-event'
+        with self._caplog.at_level(logging.INFO):
+            process_message(record, batch_item_failures)
+            assert 'Received a message with an unhandled action type: fake-event' in self._caplog.text

--- a/aws/sqs_event_manager/test/unit/message_test.py
+++ b/aws/sqs_event_manager/test/unit/message_test.py
@@ -1,0 +1,60 @@
+from pytest import fixture
+
+from sqs_event_manager.message import AWSSNSMessage
+
+
+class TestAWSSNSMessage:
+    @fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        self._caplog = caplog
+
+    def setup_method(self, cls):
+        record = {
+            'message_id': '123',
+            'receipt_handle': 'abc123',
+            'body': {
+                'Type': 'Notification',
+                'MessageId': '6f4eae69-8205-5531-84f7-f1b478aeb04',
+                'TopicArn': 'arn:aws:sns:us-east-1:XXX:aws-mp-entitlement-notification-XXX',
+                'Message': {
+                    'action': 'entitlement-updated',
+                    'customer-identifier': 'abc123',
+                    'product-code': '7hn1uo40wt6psy10ovxyh4zzn',
+                },
+                'Timestamp': '2025-01-15 16:31:50',
+                'SignatureVersion': '1',
+                'Signature': 'signature',
+                'SigningCertURL': 'https://cert.com',
+                'UnsubscribeURL': 'https://unsub.com'
+            },
+            'attributes': {
+                'ApproximateReceiveCount': '1',
+                'SentTimestamp': '1545082649183',
+                'SenderId': 'abc123',
+                'ApproximateFirstReceiveTimestamp': '1545082649185'
+            },
+            'messageAttributes': {},
+            'md5OfBody': 'md5hash',
+            'eventSource': 'aws:sqs',
+            'eventSourceARN': 'arn:aws:sqs:us-east-1:111122223333:my-queue',
+            'awsRegion': 'us-east-1'
+        }
+        self.message = AWSSNSMessage(record)
+
+    def test_get_message_id(self):
+        assert self.message.message_id == '123'
+
+    def test_get_customer_id(self):
+        assert self.message.customer_id == 'abc123'
+
+    def test_get_product_code(self):
+        assert self.message.product_code == '7hn1uo40wt6psy10ovxyh4zzn'
+
+    def test_get_receipt_handle(self):
+        assert self.message.receipt_handle == 'abc123'
+
+    def test_get_event_source_arn(self):
+        assert self.message.event_source_arn == 'arn:aws:sqs:us-east-1:111122223333:my-queue'
+
+    def test_get_action(self):
+        assert self.message.action == 'entitlement-updated'

--- a/aws/sqs_event_manager/test/unit/queue_test.py
+++ b/aws/sqs_event_manager/test/unit/queue_test.py
@@ -1,0 +1,16 @@
+from unittest.mock import MagicMock, patch
+
+from sqs_event_manager.queue import get_queue_url, delete_message
+
+
+def test_get_queue_url():
+    arn = 'arn:aws:sqs:us-east-1:111122223333:my-queue'
+    url = get_queue_url(arn)
+    assert url == 'https://sqs.us-east-1.amazonaws.com/111122223333/my-queue'
+
+
+@patch('boto3.client')
+def test_delete_message(mock_boto_client):
+    client = MagicMock()
+    mock_boto_client.return_value = client
+    delete_message('arn:aws:sqs:us-east-1:111122223333:my-queue', 'r123')


### PR DESCRIPTION
The actions for each SNS message is still to be implemented. I wanted to open a discussion here on how we want to handle the response. I think there's a couple paths.

- The sqs event manager gets the customer info and passes the data to SCC
- The sqs event manager simply lets SCC know the customers entitelments changed and expects SCC to check on the entitlements
- The sqs event manager gets the customer info and determines what the situation is (new entitlements or removed entitlements) and lets SCC know

TODO: the test for the lamdba handler