### PR TITLE
Assume role credentials

### DIFF
--- a/aws/container/sle15/appliance.kiwi
+++ b/aws/container/sle15/appliance.kiwi
@@ -44,6 +44,7 @@
         <package name="python311-awslambdaric"/>
         <package name="python311-resolve_customer"/>
         <package name="python311-sqs_event_manager"/>
+        <package name="assume_role_setup"/>
     </packages>
     <packages type="delete">
         <package name="python3-base"/>

--- a/aws/resolve_customer/README.rst
+++ b/aws/resolve_customer/README.rst
@@ -10,7 +10,7 @@ Through AWS API Gateway
 .. code::
 
     {
-        "registrationToken": "some"
+        "registrationToken": "someURLEncodedToken"
     }
 
 RESPONSE

--- a/aws/resolve_customer/README.rst
+++ b/aws/resolve_customer/README.rst
@@ -58,7 +58,19 @@ ERROR RESPONSE
         }
     }
 
-* 500: Internal Server Error
-* 503: Service unavailable, any non AWS ClientException
-* 422: no marketplace token provided / no customer_id and/or product_code provided
-* HTTP_STATUS_CODE: HTTP status code as it was provided by the client call
+
+Application handled exceptions:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* 500: App.Error.InternalServiceErrorException
+* 503: App.Error.ServiceUnavailableException
+* 422: App.Error.MissingTokenException
+* 400: App.Error.TokenException from
+       InvalidTokenException, ExpiredTokenException, ThrottlingException, DisabledApiException
+* 400: App.Error.EntitlementException from
+       InvalidParameterException, ThrottlingException
+
+Pass through exceptions:
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+* HTTP_STATUS_CODE: code and exception name as it was provided by the client call

--- a/aws/resolve_customer/package/python-resolve_customer-spec-template
+++ b/aws/resolve_customer/package/python-resolve_customer-spec-template
@@ -27,6 +27,7 @@ Source:         %{name}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Requires:       %{python_module boto3}
 Requires:       %{python_module requests}
+Requires:       %{python_module PyYAML}
 Requires:       python3 >= 3.11
 BuildRequires:  python3 >= 3.11
 BuildRequires:  %{python_module devel}
@@ -49,6 +50,7 @@ SaaS tooling for the pubcloud team.
 %install
 %pyproject_install
 %python_expand %fdupes %{buildroot}%{$python_sitelib}
+mkdir -p %{buildroot}/etc
 install -m 755 app_resolve_customer.py %{buildroot}/app_resolve_customer.py
 
 %files %{python_files}

--- a/aws/resolve_customer/pyproject.toml
+++ b/aws/resolve_customer/pyproject.toml
@@ -44,6 +44,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.11"
 requests = ">=2.25.0"
+PyYAML = ">=5.4.0"
 setuptools = ">=50"
 boto3 = ">=1.12"
 
@@ -56,6 +57,7 @@ pytest-xdist = "*"
 # type checking
 mypy = ">=0.971"
 types-requests = "*"
+types-PyYAML = "*"
 types-mock = "*"
 
 [tool.poetry.group.style]

--- a/aws/resolve_customer/resolve_customer/app.py
+++ b/aws/resolve_customer/resolve_customer/app.py
@@ -86,7 +86,7 @@ def lambda_handler(event, context):
         return json.dumps(
             error_response(
                 error_record(
-                    500, f'{type(error).__name__}: {error}', 'InitEvent'
+                    500, f'{type(error).__name__}: {error}', 'InternalServiceErrorException'
                 ), topic
             )
         )
@@ -109,7 +109,7 @@ def process_event(
         # server error including the message we got
         return error_response(
             error_record(
-                503, f'{type(oops).__name__}: {oops}', 'CSPService'
+                503, f'{type(oops).__name__}: {oops}', 'ServiceUnavailableException'
             ), topic
         )
     return {

--- a/aws/resolve_customer/resolve_customer/assume_role.py
+++ b/aws/resolve_customer/resolve_customer/assume_role.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2025 SUSE LLC.  All rights reserved.
+#
+# This file is part of suse-saas-tools
+#
+# suse-saas-tools is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+import boto3
+from botocore.exceptions import ClientError
+from resolve_customer.error import log_error
+
+
+class AWSAssumeRole:
+    """
+    Get access tokens from the token service through the
+    assumed role arn of the marketplace account
+    """
+    def __init__(self, role_arn: str, session_name: str = 'suse_saas'):
+        self.role_response = {}
+        self.error = {}
+        try:
+            sts_client = boto3.client('sts')
+            self.role_response = sts_client.assume_role(
+                RoleArn=role_arn, RoleSessionName=session_name
+            )
+        except ClientError as error:
+            self.error = error.response
+            log_error(self.error)
+
+    def get_access_key(self) -> str:
+        return self.__get('AccessKeyId')
+
+    def get_secret_access_key(self) -> str:
+        return self.__get('SecretAccessKey')
+
+    def get_session_token(self) -> str:
+        return self.__get('SessionToken')
+
+    def get_expiration_date(self) -> str:
+        return self.__get('Expiration')
+
+    def __get(self, key) -> str:
+        result = ''
+        if self.role_response.get('Credentials'):
+            result = self.role_response['Credentials'].get(key) or ''
+        return result

--- a/aws/resolve_customer/resolve_customer/defaults.py
+++ b/aws/resolve_customer/resolve_customer/defaults.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2025 SUSE LLC.  All rights reserved.
+#
+# This file is part of suse-saas-tools
+#
+# suse-saas-tools is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+import yaml
+from typing import Dict
+
+
+class Defaults:
+    @staticmethod
+    def get_assume_role_config(
+        config_file: str = '/etc/assume_role.yml'
+    ) -> Dict:
+        with open(config_file) as config:
+            return yaml.safe_load(config)

--- a/aws/resolve_customer/resolve_customer/error.py
+++ b/aws/resolve_customer/resolve_customer/error.py
@@ -46,10 +46,14 @@ def error_record(status_code: int, message: str, kind: str = 'Unknown') -> Dict:
     }
 
 
-def classify_error(error: Dict, aws_code: str, status_code: int) -> Dict:
+def classify_error(
+    error: Dict, aws_code: str, status_code: int, exception_name: str = ''
+) -> Dict:
     error_code = error['Error']['Code']
     if error_code == aws_code:
         error['ResponseMetadata']['HTTPStatusCode'] = status_code
+        if exception_name:
+            error['Error']['Code'] = exception_name
     return error
 
 

--- a/aws/resolve_customer/test/data/assume_role.yml
+++ b/aws/resolve_customer/test/data/assume_role.yml
@@ -1,0 +1,4 @@
+role:
+  arn: arn:aws:iam::123:role/Some
+  session: some_session_name
+  region: us-east-1

--- a/aws/resolve_customer/test/unit/app_test.py
+++ b/aws/resolve_customer/test/unit/app_test.py
@@ -13,7 +13,7 @@ class TestApp:
         assert lambda_handler(event={'some': 'some'}, context=Mock()) == \
             '{"isBase64Encoded": false, "statusCode": 500, ' \
             '"body": {"errors": {"Registration": "KeyError: \'body\'", ' \
-            '"Exception": "App.Error.InitEvent"}}}'
+            '"Exception": "App.Error.InternalServiceErrorException"}}}'
 
     @patch('resolve_customer.app.AWSCustomer')
     def test_lambda_handler_unexpected_error(self, mock_AWSCustomer):
@@ -26,7 +26,7 @@ class TestApp:
         ) == \
             '{"isBase64Encoded": false, "statusCode": 503, "body": ' \
             '{"errors": {"Registration": "OSError: some unexpected error", ' \
-            '"Exception": "App.Error.CSPService"}}}'
+            '"Exception": "App.Error.ServiceUnavailableException"}}}'
 
     @patch('resolve_customer.app.process_event')
     def test_lambda_handler(self, mock_process_event):

--- a/aws/resolve_customer/test/unit/assume_role_test.py
+++ b/aws/resolve_customer/test/unit/assume_role_test.py
@@ -1,0 +1,64 @@
+import logging
+from unittest.mock import (
+    patch, MagicMock
+)
+from pytest import fixture
+from datetime import datetime
+
+from botocore.exceptions import ClientError
+from resolve_customer.assume_role import AWSAssumeRole
+from resolve_customer.error import error_record
+
+
+class TestAWSAssumeRole:
+    @fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        self._caplog = caplog
+
+    @patch('boto3.client')
+    def setup_method(self, cls, mock_boto_client):
+        self.sts_client = mock_boto_client.return_value
+        self.sts_client.assume_role.return_value = {
+            'Credentials': {
+                'AccessKeyId': 'accesskey',
+                'SecretAccessKey': 'secretaccesskey',
+                'SessionToken': 'string',
+                'Expiration': format(datetime(2015, 1, 1))
+            },
+            'AssumedRoleUser': {
+                'AssumedRoleId': 'string',
+                'Arn': 'string'
+            },
+            'PackedPolicySize': 123,
+            'SourceIdentity': 'string'
+        }
+        self.assume_role = AWSAssumeRole(
+            'arn:aws:iam::some:role/PCTAccess'
+        )
+
+    @patch('boto3.client')
+    def test_setup_boto_client_raises(self, mock_boto_client):
+        error_response = error_record(
+            400, 'sts client failed'
+        )
+        error_response['Error']['Code'] = \
+            'AccessDeniedException'
+        mock_boto_client.side_effect = ClientError(
+            operation_name=MagicMock(),
+            error_response=error_response
+        )
+        with self._caplog.at_level(logging.INFO):
+            AWSAssumeRole('arn:aws:iam::some:role/PCTAccess')
+            assert 'sts client failed' in self._caplog.text
+
+    def test_get_access_key(self):
+        assert self.assume_role.get_access_key() == 'accesskey'
+
+    def test_get_secret_access_key(self):
+        assert self.assume_role.get_secret_access_key() == 'secretaccesskey'
+
+    def test_get_session_token(self):
+        assert self.assume_role.get_session_token() == 'string'
+
+    def test_get_expiration_date(self):
+        assert self.assume_role.get_expiration_date() == '2015-01-01 00:00:00'

--- a/aws/resolve_customer/test/unit/customer_test.py
+++ b/aws/resolve_customer/test/unit/customer_test.py
@@ -6,7 +6,10 @@ from pytest import fixture
 
 from botocore.exceptions import ClientError
 from resolve_customer.error import error_record
+from resolve_customer.defaults import Defaults
 from resolve_customer.customer import AWSCustomer
+
+role_config = Defaults.get_assume_role_config('../data/assume_role.yml')
 
 
 class TestAWSCustomer:
@@ -15,7 +18,15 @@ class TestAWSCustomer:
         self._caplog = caplog
 
     @patch('boto3.client')
-    def setup_method(self, cls, mock_boto_client):
+    @patch('resolve_customer.customer.Defaults.get_assume_role_config')
+    @patch('resolve_customer.customer.AWSAssumeRole')
+    def setup_method(
+        self, cls, mock_AWSAssumeRole, mock_get_assume_role_config,
+        mock_boto_client
+    ):
+        mock_get_assume_role_config.return_value = role_config
+        assume_role = MagicMock()
+        mock_AWSAssumeRole.return_value = assume_role
         self.marketplace = mock_boto_client.return_value
         self.marketplace.resolve_customer.return_value = {
             'CustomerIdentifier': 'id',
@@ -23,15 +34,32 @@ class TestAWSCustomer:
             'ProductCode': 'some'
         }
         self.customer = AWSCustomer('token')
+        mock_boto_client.assert_called_once_with(
+            'meteringmarketplace',
+            region_name='us-east-1',
+            aws_access_key_id=assume_role.get_access_key.return_value,
+            aws_secret_access_key=assume_role.get_secret_access_key.return_value,
+            aws_session_token=assume_role.get_session_token.return_value
+        )
 
     @patch('boto3.client')
-    def test_setup_incomplete(self, mock_boto_client):
+    @patch('resolve_customer.customer.Defaults.get_assume_role_config')
+    @patch('resolve_customer.customer.AWSAssumeRole')
+    def test_setup_incomplete(
+        self, mock_AWSAssumeRole, mock_get_assume_role_config,
+        mock_boto_client
+    ):
         with self._caplog.at_level(logging.INFO):
             AWSCustomer('')
             assert 'no marketplace token provided' in self._caplog.text
 
     @patch('boto3.client')
-    def test_setup_boto_client_raises(self, mock_boto_client):
+    @patch('resolve_customer.customer.Defaults.get_assume_role_config')
+    @patch('resolve_customer.customer.AWSAssumeRole')
+    def test_setup_boto_client_raises(
+        self, mock_AWSAssumeRole, mock_get_assume_role_config,
+        mock_boto_client
+    ):
         error_response = error_record(
             400, 'meteringmarketplace client failed'
         )

--- a/aws/resolve_customer/test/unit/defaults_test.py
+++ b/aws/resolve_customer/test/unit/defaults_test.py
@@ -1,0 +1,12 @@
+from resolve_customer.defaults import Defaults
+
+
+class TestDefaults:
+    def test_get_assume_role_config(self):
+        assert Defaults.get_assume_role_config('../data/assume_role.yml') == {
+            'role': {
+                'arn': 'arn:aws:iam::123:role/Some',
+                'session': 'some_session_name',
+                'region': 'us-east-1'
+            }
+        }

--- a/aws/resolve_customer/test/unit/entitlements_test.py
+++ b/aws/resolve_customer/test/unit/entitlements_test.py
@@ -6,7 +6,10 @@ from pytest import fixture
 
 from botocore.exceptions import ClientError
 from resolve_customer.error import error_record
+from resolve_customer.defaults import Defaults
 from resolve_customer.entitlements import AWSCustomerEntitlement
+
+role_config = Defaults.get_assume_role_config('../data/assume_role.yml')
 
 
 class TestAWSCustomerEntitlement:
@@ -15,7 +18,15 @@ class TestAWSCustomerEntitlement:
         self._caplog = caplog
 
     @patch('boto3.client')
-    def setup_method(self, cls, mock_boto_client):
+    @patch('resolve_customer.entitlements.Defaults.get_assume_role_config')
+    @patch('resolve_customer.entitlements.AWSAssumeRole')
+    def setup_method(
+        self, cls, mock_AWSAssumeRole, mock_get_assume_role_config,
+        mock_boto_client
+    ):
+        mock_get_assume_role_config.return_value = role_config
+        assume_role = MagicMock()
+        mock_AWSAssumeRole.return_value = assume_role
         self.marketplace = mock_boto_client.return_value
         self.marketplace.get_entitlements.return_value = {
             'Entitlements': [
@@ -35,15 +46,32 @@ class TestAWSCustomerEntitlement:
             'NextToken': 'some'
         }
         self.entitlements = AWSCustomerEntitlement('id', 'product')
+        mock_boto_client.assert_called_once_with(
+            'marketplace-entitlement',
+            region_name='us-east-1',
+            aws_access_key_id=assume_role.get_access_key.return_value,
+            aws_secret_access_key=assume_role.get_secret_access_key.return_value,
+            aws_session_token=assume_role.get_session_token.return_value
+        )
 
     @patch('boto3.client')
-    def test_setup_incomplete(self, mock_boto_client):
+    @patch('resolve_customer.entitlements.Defaults.get_assume_role_config')
+    @patch('resolve_customer.entitlements.AWSAssumeRole')
+    def test_setup_incomplete(
+        self, mock_AWSAssumeRole, mock_get_assume_role_config,
+        mock_boto_client
+    ):
         with self._caplog.at_level(logging.INFO):
             AWSCustomerEntitlement('', '')
             assert 'no customer_id and/or product_code' in self._caplog.text
 
     @patch('boto3.client')
-    def test_setup_boto_client_raises(self, mock_boto_client):
+    @patch('resolve_customer.entitlements.Defaults.get_assume_role_config')
+    @patch('resolve_customer.entitlements.AWSAssumeRole')
+    def test_setup_boto_client_raises(
+        self, mock_AWSAssumeRole, mock_get_assume_role_config,
+        mock_boto_client
+    ):
         mock_boto_client.side_effect = ClientError(
             operation_name=MagicMock(),
             error_response=error_record(

--- a/aws/resolve_customer/test/unit/error_test.py
+++ b/aws/resolve_customer/test/unit/error_test.py
@@ -6,7 +6,10 @@ from resolve_customer.error import (
 class TestErrorMethods:
     def test_classify_error(self):
         error = error_record(400, 'some_error', 'Some')
+        assert error['ResponseMetadata']['HTTPStatusCode'] == 400
+        assert error['Error']['Code'] == 'App.Error.Some'
         error_classified = classify_error(
-            error, 'App.Error.Some', 500
+            error, 'App.Error.Some', 500, 'SomeException'
         )
         assert error_classified['ResponseMetadata']['HTTPStatusCode'] == 500
+        assert error_classified['Error']['Code'] == 'SomeException'


### PR DESCRIPTION
Add new class AWSAssumeRole
    
An instance of AWSAssumeRole allows to fetch temporary credentials to access API endpoints from an assumed role arn that can point to another AWS account and IAM role. We make use of this concept because all marketplace accounts will live outside of the account that setups the SUSE SaaS tool chain. The required configuration data to construct an instance of AWSAssumeRole are taken from a configuration file named /etc/assume_role.yml. The configuration file is packaged as a sub-package and can be provided with different content in a production setup.