### PR TITLE
Classify and group error types

### DIFF
--- a/aws/resolve_customer/README.rst
+++ b/aws/resolve_customer/README.rst
@@ -58,7 +58,19 @@ ERROR RESPONSE
         }
     }
 
-* 500: Internal Server Error
-* 503: Service unavailable, any non AWS ClientException
-* 422: no marketplace token provided / no customer_id and/or product_code provided
-* HTTP_STATUS_CODE: HTTP status code as it was provided by the client call
+
+Application handled exceptions:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* 500: App.Error.InternalServiceErrorException
+* 503: App.Error.ServiceUnavailableException
+* 422: App.Error.MissingTokenException
+* 400: App.Error.TokenException from
+       InvalidTokenException, ExpiredTokenException, ThrottlingException, DisabledApiException
+* 400: App.Error.EntitlementException from
+       InvalidParameterException, ThrottlingException
+
+Pass through exceptions:
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+* HTTP_STATUS_CODE: code and exception name as it was provided by the client call

--- a/aws/resolve_customer/resolve_customer/app.py
+++ b/aws/resolve_customer/resolve_customer/app.py
@@ -86,7 +86,7 @@ def lambda_handler(event, context):
         return json.dumps(
             error_response(
                 error_record(
-                    500, f'{type(error).__name__}: {error}', 'InitEvent'
+                    500, f'{type(error).__name__}: {error}', 'InternalServiceErrorException'
                 ), topic
             )
         )
@@ -109,7 +109,7 @@ def process_event(
         # server error including the message we got
         return error_response(
             error_record(
-                503, f'{type(oops).__name__}: {oops}', 'CSPService'
+                503, f'{type(oops).__name__}: {oops}', 'ServiceUnavailableException'
             ), topic
         )
     return {

--- a/aws/resolve_customer/resolve_customer/error.py
+++ b/aws/resolve_customer/resolve_customer/error.py
@@ -46,10 +46,14 @@ def error_record(status_code: int, message: str, kind: str = 'Unknown') -> Dict:
     }
 
 
-def classify_error(error: Dict, aws_code: str, status_code: int) -> Dict:
+def classify_error(
+    error: Dict, aws_code: str, status_code: int, exception_name: str = ''
+) -> Dict:
     error_code = error['Error']['Code']
     if error_code == aws_code:
         error['ResponseMetadata']['HTTPStatusCode'] = status_code
+        if exception_name:
+            error['Error']['Code'] = exception_name
     return error
 
 

--- a/aws/resolve_customer/test/unit/app_test.py
+++ b/aws/resolve_customer/test/unit/app_test.py
@@ -13,7 +13,7 @@ class TestApp:
         assert lambda_handler(event={'some': 'some'}, context=Mock()) == \
             '{"isBase64Encoded": false, "statusCode": 500, ' \
             '"body": {"errors": {"Registration": "KeyError: \'body\'", ' \
-            '"Exception": "App.Error.InitEvent"}}}'
+            '"Exception": "App.Error.InternalServiceErrorException"}}}'
 
     @patch('resolve_customer.app.AWSCustomer')
     def test_lambda_handler_unexpected_error(self, mock_AWSCustomer):
@@ -26,7 +26,7 @@ class TestApp:
         ) == \
             '{"isBase64Encoded": false, "statusCode": 503, "body": ' \
             '{"errors": {"Registration": "OSError: some unexpected error", ' \
-            '"Exception": "App.Error.CSPService"}}}'
+            '"Exception": "App.Error.ServiceUnavailableException"}}}'
 
     @patch('resolve_customer.app.process_event')
     def test_lambda_handler(self, mock_process_event):

--- a/aws/resolve_customer/test/unit/error_test.py
+++ b/aws/resolve_customer/test/unit/error_test.py
@@ -6,7 +6,10 @@ from resolve_customer.error import (
 class TestErrorMethods:
     def test_classify_error(self):
         error = error_record(400, 'some_error', 'Some')
+        assert error['ResponseMetadata']['HTTPStatusCode'] == 400
+        assert error['Error']['Code'] == 'App.Error.Some'
         error_classified = classify_error(
-            error, 'App.Error.Some', 500
+            error, 'App.Error.Some', 500, 'SomeException'
         )
         assert error_classified['ResponseMetadata']['HTTPStatusCode'] == 500
+        assert error_classified['Error']['Code'] == 'SomeException'


### PR DESCRIPTION
Per request from the SCC team the following commit implements CSP API error classification to match with the SCC error handling