### PR TITLE
Do not return entitlements error

### DIFF
--- a/aws/sqs_event_manager/sqs_event_manager/app.py
+++ b/aws/sqs_event_manager/sqs_event_manager/app.py
@@ -103,13 +103,11 @@ def process_message(record: dict, batch_item_failures: dict):
                 message.product_code
             )
             if entitlements.error:
-                logger.error(
+                raise Exception(
                     'Exception getting entitlements for customer '
                     f'{message.customer_id} and product '
                     '{message.product_code}. {entitlements.error}'
                 )
-                batch_item_failures.append({'itemIdentifier': message.message_id})
-                return
 
             request = {  # noqa TODO: Cleanup noqa
                 'customerIdentifier': message.customer_id,

--- a/aws/sqs_event_manager/sqs_event_manager/app.py
+++ b/aws/sqs_event_manager/sqs_event_manager/app.py
@@ -103,7 +103,13 @@ def process_message(record: dict, batch_item_failures: dict):
                 message.product_code
             )
             if entitlements.error:
-                return error_response(400, entitlements.error)
+                logger.error(
+                    'Exception getting entitlements for customer '
+                    f'{message.customer_id} and product '
+                    '{message.product_code}. {entitlements.error}'
+                )
+                batch_item_failures.append({'itemIdentifier': message.message_id})
+                return
 
             request = {  # noqa TODO: Cleanup noqa
                 'customerIdentifier': message.customer_id,


### PR DESCRIPTION
In the case of an error getting entitlements log the error and add the message to the batch failure list. This will allow the message to be processed later.