### PR TITLE
Add support for multiple marketplace accounts

### DIFF
--- a/aws/resolve_customer/resolve_customer/customer.py
+++ b/aws/resolve_customer/resolve_customer/customer.py
@@ -35,14 +35,12 @@ class AWSCustomer:
         if urlEncodedtoken:
             try:
                 token = urllib.parse.unquote(urlEncodedtoken)
-                assume_role_config = Defaults.get_assume_role_config()
                 assume_role = AWSAssumeRole(
-                    assume_role_config['role']['arn'],
-                    assume_role_config['role']['session']
+                    Defaults.get_assume_role_config()
                 )
                 marketplace = boto3.client(
                     'meteringmarketplace',
-                    region_name=assume_role_config['role']['region'],
+                    region_name=assume_role.get_region(),
                     aws_access_key_id=assume_role.get_access_key(),
                     aws_secret_access_key=assume_role.get_secret_access_key(),
                     aws_session_token=assume_role.get_session_token()

--- a/aws/resolve_customer/resolve_customer/defaults.py
+++ b/aws/resolve_customer/resolve_customer/defaults.py
@@ -23,6 +23,6 @@ class Defaults:
     @staticmethod
     def get_assume_role_config(
         config_file: str = '/etc/assume_role.yml'
-    ) -> Dict:
+    ) -> Dict[str, Dict[str, Dict[str, str]]]:
         with open(config_file) as config:
             return yaml.safe_load(config)

--- a/aws/resolve_customer/resolve_customer/entitlements.py
+++ b/aws/resolve_customer/resolve_customer/entitlements.py
@@ -34,14 +34,12 @@ class AWSCustomerEntitlement:
         self.error = {}
         if customer_id and product_code:
             try:
-                assume_role_config = Defaults.get_assume_role_config()
                 assume_role = AWSAssumeRole(
-                    assume_role_config['role']['arn'],
-                    assume_role_config['role']['session']
+                    Defaults.get_assume_role_config()
                 )
                 marketplace = boto3.client(
                     'marketplace-entitlement',
-                    region_name=assume_role_config['role']['region'],
+                    region_name=assume_role.get_region(),
                     aws_access_key_id=assume_role.get_access_key(),
                     aws_secret_access_key=assume_role.get_secret_access_key(),
                     aws_session_token=assume_role.get_session_token()

--- a/aws/resolve_customer/test/data/assume_role.yml
+++ b/aws/resolve_customer/test/data/assume_role.yml
@@ -1,4 +1,7 @@
 role:
-  arn: arn:aws:iam::123:role/Some
-  session: some_session_name
-  region: us-east-1
+  us-east-1:
+      arn: arn:aws:iam::123:role/Some
+      session: some_session_name
+  eu-central-1:
+      arn: arn:aws:iam::456:role/SomeOther
+      session: some_session_name

--- a/aws/resolve_customer/test/unit/assume_role_test.py
+++ b/aws/resolve_customer/test/unit/assume_role_test.py
@@ -17,6 +17,13 @@ class TestAWSAssumeRole:
 
     @patch('boto3.client')
     def setup_method(self, cls, mock_boto_client):
+        self.config = {
+            'role': {
+                'us-east-1': {
+                    'arn': 'arn:aws:iam::some:role/Some', 'session': 'some'
+                }
+            }
+        }
         self.sts_client = mock_boto_client.return_value
         self.sts_client.assume_role.return_value = {
             'Credentials': {
@@ -32,9 +39,7 @@ class TestAWSAssumeRole:
             'PackedPolicySize': 123,
             'SourceIdentity': 'string'
         }
-        self.assume_role = AWSAssumeRole(
-            'arn:aws:iam::some:role/PCTAccess'
-        )
+        self.assume_role = AWSAssumeRole(self.config)
 
     @patch('boto3.client')
     def test_setup_boto_client_raises(self, mock_boto_client):
@@ -47,9 +52,38 @@ class TestAWSAssumeRole:
             operation_name=MagicMock(),
             error_response=error_response
         )
-        with self._caplog.at_level(logging.INFO):
-            AWSAssumeRole('arn:aws:iam::some:role/PCTAccess')
+        with self._caplog.at_level(logging.ERROR):
+            AWSAssumeRole(self.config)
             assert 'sts client failed' in self._caplog.text
+
+    @patch('boto3.client')
+    def test_no_role_success(self, mock_boto_client):
+        error_response = error_record(
+            400, 'sts client failed'
+        )
+        error_response['Error']['Code'] = \
+            'AccessDeniedException'
+        mock_boto_client.side_effect = ClientError(
+            operation_name=MagicMock(),
+            error_response=error_response
+        )
+        config = {
+            'role': {
+                'us-east-1': {
+                    'arn': 'arn:aws:iam::some1:role/Some', 'session': 'some1'
+                },
+                'eu-central-1': {
+                    'arn': 'arn:aws:iam::some2:role/Some', 'session': 'some2'
+                }
+            }
+        }
+        with self._caplog.at_level(logging.ERROR):
+            role = AWSAssumeRole(config)
+            assert 'sts client failed' in self._caplog.text
+            assert role.error_count == 2
+
+    def test_get_region(self):
+        assert self.assume_role.get_region() == 'us-east-1'
 
     def test_get_access_key(self):
         assert self.assume_role.get_access_key() == 'accesskey'

--- a/aws/resolve_customer/test/unit/customer_test.py
+++ b/aws/resolve_customer/test/unit/customer_test.py
@@ -36,7 +36,7 @@ class TestAWSCustomer:
         self.customer = AWSCustomer('token')
         mock_boto_client.assert_called_once_with(
             'meteringmarketplace',
-            region_name='us-east-1',
+            region_name=assume_role.get_region.return_value,
             aws_access_key_id=assume_role.get_access_key.return_value,
             aws_secret_access_key=assume_role.get_secret_access_key.return_value,
             aws_session_token=assume_role.get_session_token.return_value

--- a/aws/resolve_customer/test/unit/defaults_test.py
+++ b/aws/resolve_customer/test/unit/defaults_test.py
@@ -5,8 +5,13 @@ class TestDefaults:
     def test_get_assume_role_config(self):
         assert Defaults.get_assume_role_config('../data/assume_role.yml') == {
             'role': {
-                'arn': 'arn:aws:iam::123:role/Some',
-                'session': 'some_session_name',
-                'region': 'us-east-1'
+                'us-east-1': {
+                    'arn': 'arn:aws:iam::123:role/Some',
+                    'session': 'some_session_name',
+                },
+                'eu-central-1': {
+                    'arn': 'arn:aws:iam::456:role/SomeOther',
+                    'session': 'some_session_name'
+                }
             }
         }

--- a/aws/resolve_customer/test/unit/entitlements_test.py
+++ b/aws/resolve_customer/test/unit/entitlements_test.py
@@ -48,7 +48,7 @@ class TestAWSCustomerEntitlement:
         self.entitlements = AWSCustomerEntitlement('id', 'product')
         mock_boto_client.assert_called_once_with(
             'marketplace-entitlement',
-            region_name='us-east-1',
+            region_name=assume_role.get_region.return_value,
             aws_access_key_id=assume_role.get_access_key.return_value,
             aws_secret_access_key=assume_role.get_secret_access_key.return_value,
             aws_session_token=assume_role.get_session_token.return_value


### PR DESCRIPTION
If a subscription is performed it will originate from a specific marketplace account ID. This commit allows to specify multiple marketplace account roles to check the received subscription token for.