### PR TITLE
Various fixes to the sqs event manager

### DIFF
--- a/.github/workflows/ci-code-style.yml
+++ b/.github/workflows/ci-code-style.yml
@@ -27,3 +27,4 @@ jobs:
       - name: Run code checks
         run: |
           make -C aws/resolve_customer check
+          make -C aws/sqs_event_manager check

--- a/.github/workflows/ci-units-types.yml
+++ b/.github/workflows/ci-units-types.yml
@@ -25,6 +25,8 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install poetry
       - name: Run unit and type tests
-        run: make -C aws/resolve_customer test
+        run: |
+          make -C aws/resolve_customer test
+          make -C aws/sqs_event_manager test
         env:
           PY_VER: ${{ matrix.python-version }}

--- a/aws/sqs_event_manager/pyproject.toml
+++ b/aws/sqs_event_manager/pyproject.toml
@@ -58,6 +58,7 @@ pytest-xdist = "*"
 # type checking
 mypy = ">=0.971"
 types-requests = "*"
+types-PyYAML = "*"
 types-mock = "*"
 
 [tool.poetry.group.style]

--- a/aws/sqs_event_manager/test/unit/.coveragerc
+++ b/aws/sqs_event_manager/test/unit/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+omit =
+    */version.py
+
+[report]
+omit =
+    */version.py

--- a/aws/sqs_event_manager/test/unit/defaults_test.py
+++ b/aws/sqs_event_manager/test/unit/defaults_test.py
@@ -3,6 +3,6 @@ from sqs_event_manager.defaults import Defaults
 
 class TestDefaults:
     def test_get_sqs_event_manager_config(self):
-        assert Defaults.get_sqs_event_manager_config('../data/sts_event_manager.yml') == {
+        assert Defaults.get_sqs_event_manager_config('../data/sqs_event_manager.yml') == {
             'entitlement_change_url': 'https://inform-me-of-changes.com'
         }

--- a/aws/sqs_event_manager/test/unit/message_test.py
+++ b/aws/sqs_event_manager/test/unit/message_test.py
@@ -1,5 +1,3 @@
-import json
-
 from pytest import fixture
 
 from sqs_event_manager.message import AWSSNSMessage
@@ -11,46 +9,39 @@ class TestAWSSNSMessage:
         self._caplog = caplog
 
     def setup_method(self, cls):
-        message = json.dumps(
-            {
-                'action': 'entitlement-updated',
-                'customer-identifier': 'abc123',
-                'product-code': '7hn1uo40wt6psy10ovxyh4zzn',
-            }
-        )
-        body = json.dumps(
-            {
-                'Type': 'Notification',
-                'MessageId': '6f4eae69-8205-5531-84f7-f1b478aeb04',
-                'TopicArn': 'arn:aws:sns:us-east-1:XXX:aws-mp-entitlement-notification-XXX',
-                'Message': message,
-                'Timestamp': '2025-01-15 16:31:50',
-                'SignatureVersion': '1',
-                'Signature': 'signature',
-                'SigningCertURL': 'https://cert.com',
-                'UnsubscribeURL': 'https://unsub.com'
-            }
-        )
         record = {
-            'messageId': '123',
-            'receiptHandle': 'abc123',
-            'body': body,
+            'messageId': 'c7b2c992-4f07-478e-bfb8-f577e8310550',
+            'receiptHandle': 'AQEBZ...',
+            'body': '{\
+                "Type": "Notification", \
+                "MessageId": "123", \
+                "TopicArn": "arn:aws:sns:us-east-1:XXX:aws-mp-entitlement-notification-XXX", \
+                "Message" : "{\\n    \\"action\\": \\"entitlement-updated\\",\\n    \\"customer-identifier\\": \\" abc123\\",\\n    \\"product-code\\": \\"7hn1uo40wt6psy10ovxyh4zzn\\"\\n}",\n\
+                "Timestamp": "2025-01-15 16:31:50", \
+                "SignatureVersion": "1", \
+                "Signature": "abc123", \
+                "SigningCertURL": "string", \
+                "UnsubscribeURL": "string"\
+            }',
             'attributes': {
                 'ApproximateReceiveCount': '1',
-                'SentTimestamp': '1545082649183',
-                'SenderId': 'abc123',
-                'ApproximateFirstReceiveTimestamp': '1545082649185'
+                'SentTimestamp': '1738513550582',
+                'SequenceNumber': '18891803542658543872',
+                'MessageGroupId': '586474de88e09',
+                'SenderId': 'AIDA3ZKWXZJCWPK4AZP3G',
+                'MessageDeduplicationId': 'f78f3e796ac0abf15635b400b459bed17fb11608ae77cc95f6f850b165ef2faa',
+                'ApproximateFirstReceiveTimestamp': '1738513550582'
             },
             'messageAttributes': {},
-            'md5OfBody': 'md5hash',
+            'md5OfBody': '3f1b30bf45ba94b6a1cee5f9db39f60a',
             'eventSource': 'aws:sqs',
-            'eventSourceARN': 'arn:aws:sqs:us-east-1:111122223333:my-queue',
-            'awsRegion': 'us-east-1'
+            'eventSourceARN': 'arn:aws:sqs:eu-central-1:12345:ms-testing.fifo',
+            'awsRegion': 'eu-central-1'
         }
         self.message = AWSSNSMessage(record)
 
     def test_get_message_id(self):
-        assert self.message.message_id == '123'
+        assert self.message.message_id == 'c7b2c992-4f07-478e-bfb8-f577e8310550'
 
     def test_get_customer_id(self):
         assert self.message.customer_id == 'abc123'
@@ -59,10 +50,10 @@ class TestAWSSNSMessage:
         assert self.message.product_code == '7hn1uo40wt6psy10ovxyh4zzn'
 
     def test_get_receipt_handle(self):
-        assert self.message.receipt_handle == 'abc123'
+        assert self.message.receipt_handle == 'AQEBZ...'
 
     def test_get_event_source_arn(self):
-        assert self.message.event_source_arn == 'arn:aws:sqs:us-east-1:111122223333:my-queue'
+        assert self.message.event_source_arn == 'arn:aws:sqs:eu-central-1:12345:ms-testing.fifo'
 
     def test_get_action(self):
         assert self.message.action == 'entitlement-updated'


### PR DESCRIPTION
I did a setup of an sqs queue in AWS and connected it to the sqs event manager as a lambda. Next I sent an event to the queue that should simulate an entitlement-updated event as follows:

```python
session = boto3.Session(profile_name='suse-pct')
sqs = session.resource('sqs')
alias_queue sqs.get_queue_by_name(QueueName='ms-testing.fifo')
data = json.dumps(
    {
        'Type' : 'Notification',
        'MessageId' : 'uuid',
        'TopicArn' : 'arn:aws:sns:us-east-1:XXX:aws-mp-entitlement-notification-XXX',
        'Message' : {
            'action': 'entitlement-updated',
            'customer-identifier': 'string',
            'product-code': 'string'
        },
        'Timestamp' : '2025-01-15 16:31:50',
        'SignatureVersion' : '1',
        'Signature' : 'abc123',
        'SigningCertURL' : 'string',
        'UnsubscribeURL' : 'string'
    }
)
alias_queue.send_message(
    MessageBody=data, MessageGroupId='123456789'
)
```

I found it particularly hard to debug the process and added some code changes resulting in this PR

* print event and context to the log for debugging
* Fixed duplicate json.loads, it should be enough to json.loads the body once
* Cleanup and fixed the unit tests and typing annotations
* Activate github actions for sqs event manager code
* Use 1:1 copy of the event data for unit testing (no sensitive data included)