### PR TITLE
Add AWSDataZone class

### DIFF
--- a/aws/resolve_customer/resolve_customer/datazone.py
+++ b/aws/resolve_customer/resolve_customer/datazone.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2025 SUSE LLC.  All rights reserved.
+#
+# This file is part of suse-saas-tools
+#
+# suse-saas-tools is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+import boto3
+from botocore.exceptions import ClientError
+from resolve_customer.defaults import Defaults
+from resolve_customer.assume_role import AWSAssumeRole
+from resolve_customer.error import (
+    error_record, log_error
+)
+from typing import (
+    List, Dict
+)
+
+
+class AWSDataZone:
+    """
+    Get and manage subscriptions
+    """
+    def __init__(self, domain_id: str, subscription_id: str):
+        self.subscription = {}
+        self.error: Dict = {}
+        self.error_list: List[Dict] = []
+        config = Defaults.get_assume_role_config()
+        role: Dict[str, Dict[str, str]] = config.get('role') or {}
+        if domain_id and subscription_id and role:
+            for region in sorted(role.keys()):
+                try:
+                    assume_role = AWSAssumeRole(
+                        role[region]['arn'], role[region]['session']
+                    )
+                    datazone = boto3.client(
+                        'datazone',
+                        region_name=region,
+                        aws_access_key_id=assume_role.get_access_key(),
+                        aws_secret_access_key=assume_role.get_secret_access_key(),
+                        aws_session_token=assume_role.get_session_token()
+                    )
+                    self.subscription = datazone.get_subscription(
+                        domainIdentifier=domain_id,
+                        identifier=subscription_id
+                    )
+                    # success, clear all errors that happened so far
+                    # and return from the constructor in this state
+                    self.error = {}
+                    self.error_list = []
+                    return
+                except ClientError as error:
+                    self.error = error.response
+                    self.error_list.append(self.error)
+
+            # All attempts failed, log errors
+            for issue in self.error_list:
+                log_error(issue)
+        else:
+            self.error = error_record(
+                500, 'no domain_id/subscription_id and/or role provided',
+                'InternalServiceErrorException'
+            )
+            log_error(self.error)
+
+    def get_subscription(self) -> Dict:
+        return self.subscription

--- a/aws/resolve_customer/test/unit/datazone_test.py
+++ b/aws/resolve_customer/test/unit/datazone_test.py
@@ -1,0 +1,162 @@
+import logging
+from unittest.mock import (
+    patch, MagicMock, call
+)
+from pytest import fixture
+
+from botocore.exceptions import ClientError
+from resolve_customer.error import error_record
+from resolve_customer.defaults import Defaults
+from resolve_customer.datazone import AWSDataZone
+
+role_config = Defaults.get_assume_role_config('../data/assume_role.yml')
+
+
+class TestAWSDataZone:
+    @fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        self._caplog = caplog
+
+    @patch('boto3.client')
+    @patch('resolve_customer.datazone.Defaults.get_assume_role_config')
+    @patch('resolve_customer.datazone.AWSAssumeRole')
+    def setup_method(
+        self, cls, mock_AWSAssumeRole, mock_get_assume_role_config,
+        mock_boto_client
+    ):
+        mock_get_assume_role_config.return_value = role_config
+        assume_role = MagicMock()
+        mock_AWSAssumeRole.return_value = assume_role
+        self.marketplace = mock_boto_client.return_value
+        self.marketplace.get_subscription.return_value = {
+            'createdAt': 'datestring',
+            'createdBy': 'string',
+            'domainId': 'string',
+            'id': 'string',
+            'retainPermissions': True,
+            'status': 'APPROVED',
+            'subscribedListing': {
+                'description': 'string',
+                'id': 'string',
+                'item': {
+                    'assetListing': {
+                        'assetScope': {
+                            'assetId': 'string',
+                            'errorMessage': 'string',
+                            'filterIds': [
+                                'string',
+                            ],
+                            'status': 'string'
+                        },
+                        'entityId': 'string',
+                        'entityRevision': 'string',
+                        'entityType': 'string',
+                        'forms': 'string',
+                        'glossaryTerms': [
+                            {
+                                'name': 'string',
+                                'shortDescription': 'string'
+                            },
+                        ]
+                    },
+                    'productListing': {
+                        'assetListings': [
+                            {
+                                'entityId': 'string',
+                                'entityRevision': 'string',
+                                'entityType': 'string'
+                            },
+                        ],
+                        'description': 'string',
+                        'entityId': 'string',
+                        'entityRevision': 'string',
+                        'glossaryTerms': [
+                            {
+                                'name': 'string',
+                                'shortDescription': 'string'
+                            },
+                        ],
+                        'name': 'string'
+                    }
+                },
+                'name': 'string',
+                'ownerProjectId': 'string',
+                'ownerProjectName': 'string',
+                'revision': 'string'
+            },
+            'subscribedPrincipal': {
+                'project': {
+                    'id': 'string',
+                    'name': 'string'
+                }
+            },
+            'subscriptionRequestId': 'string',
+            'updatedAt': 'datestring',
+            'updatedBy': 'string'
+        }
+        self.subscription = AWSDataZone('domain_id', 'subscription_id')
+        mock_boto_client.assert_called_once_with(
+            'datazone',
+            region_name='eu-central-1',
+            aws_access_key_id=assume_role.get_access_key.return_value,
+            aws_secret_access_key=assume_role.get_secret_access_key.return_value,
+            aws_session_token=assume_role.get_session_token.return_value
+        )
+
+    @patch('boto3.client')
+    @patch('resolve_customer.datazone.Defaults.get_assume_role_config')
+    @patch('resolve_customer.datazone.AWSAssumeRole')
+    def test_setup_incomplete(
+        self, mock_AWSAssumeRole, mock_get_assume_role_config,
+        mock_boto_client
+    ):
+        with self._caplog.at_level(logging.INFO):
+            AWSDataZone('', '')
+            assert 'no domain_id/subscription_id and/or role' in self._caplog.text
+
+    @patch('boto3.client')
+    @patch('resolve_customer.datazone.Defaults.get_assume_role_config')
+    @patch('resolve_customer.datazone.AWSAssumeRole')
+    @patch('resolve_customer.datazone.log_error')
+    def test_setup_boto_client_raises(
+        self, mock_log_error, mock_AWSAssumeRole,
+        mock_get_assume_role_config, mock_boto_client
+    ):
+        mock_get_assume_role_config.return_value = role_config
+        mock_boto_client.side_effect = ClientError(
+            operation_name=MagicMock(),
+            error_response=error_record(
+                400, 'datazone client failed'
+            )
+        )
+        with self._caplog.at_level(logging.ERROR):
+            AWSDataZone('domain_id', 'subscription_id')
+        assert mock_log_error.call_args_list == [
+            call(
+                {
+                    'ResponseMetadata': {
+                        'HTTPStatusCode': 400
+                    },
+                    'Error': {
+                        'Message': 'datazone client failed',
+                        'Code': 'App.Error.Unknown'
+                    }
+                }
+            ),
+            call(
+                {
+                    'ResponseMetadata': {
+                        'HTTPStatusCode': 400
+                    },
+                    'Error': {
+                        'Message': 'datazone client failed',
+                        'Code': 'App.Error.Unknown'
+                    }
+                }
+            )
+        ]
+
+    def test_get_subscription(self):
+        assert self.subscription.get_subscription().get(
+            'retainPermissions'
+        ) is True


### PR DESCRIPTION
Add AWSDataZone class to allow retrieving information about a subscription matching a domain and subscription ID. This PR was done in preparation to the rancher SaaS offering