### PR TITLE
Add basic authentication for sqs manager

### DIFF
--- a/aws/sqs_event_manager/sqs_event_manager/app.py
+++ b/aws/sqs_event_manager/sqs_event_manager/app.py
@@ -151,11 +151,12 @@ def process_message(record: Dict) -> Dict[str, Union[str, bool]]:
                 'entitlements': entitlements.get_entitlements()
             }
             sqs_event_manager_config = Defaults.get_sqs_event_manager_config()
-            auth_token = sqs_event_manager_config['auth_token']
             headers = {
-                'Content-Type': 'application/json',
-                'Authorization': f'Bearer {auth_token}'
+                'Content-Type': 'application/json'
             }
+            auth_token = sqs_event_manager_config.get('auth_token')
+            if auth_token:
+                headers['Authorization'] = f'Bearer {auth_token}'
             http_post_response = requests.post(
                 sqs_event_manager_config['entitlement_change_url'],
                 data=request_data,

--- a/aws/sqs_event_manager/sqs_event_manager/app.py
+++ b/aws/sqs_event_manager/sqs_event_manager/app.py
@@ -150,10 +150,16 @@ def process_message(record: Dict) -> Dict[str, Union[str, bool]]:
                 'productCode': product_code,
                 'entitlements': entitlements.get_entitlements()
             }
-            sts_event_manager_config = Defaults.get_sqs_event_manager_config()
+            sqs_event_manager_config = Defaults.get_sqs_event_manager_config()
+            auth_token = sqs_event_manager_config['auth_token']
+            headers = {
+                'Content-Type': 'application/json',
+                'Authorization': f'Bearer {auth_token}'
+            }
             http_post_response = requests.post(
-                sts_event_manager_config['entitlement_change_url'],
-                data=request_data
+                sqs_event_manager_config['entitlement_change_url'],
+                data=request_data,
+                headers=headers
             )
             http_post_response.raise_for_status()
             result['status'] = format(http_post_response.status_code)

--- a/aws/sqs_event_manager/test/data/sqs_event_manager.yml
+++ b/aws/sqs_event_manager/test/data/sqs_event_manager.yml
@@ -1,1 +1,2 @@
 entitlement_change_url: https://inform-me-of-changes.com
+auth_token: some

--- a/aws/sqs_event_manager/test/unit/defaults_test.py
+++ b/aws/sqs_event_manager/test/unit/defaults_test.py
@@ -4,5 +4,6 @@ from sqs_event_manager.defaults import Defaults
 class TestDefaults:
     def test_get_sqs_event_manager_config(self):
         assert Defaults.get_sqs_event_manager_config('../data/sqs_event_manager.yml') == {
-            'entitlement_change_url': 'https://inform-me-of-changes.com'
+            'entitlement_change_url': 'https://inform-me-of-changes.com',
+            'auth_token': 'some'
         }


### PR DESCRIPTION
sqs manager reports back to an SCC endpoint which requires basic authentication. This commit adds the required bearer token to be send in the header. The token itself is part of the config file and kept in the container.
This Fixes #23