### PR TITLE
Fix product code retrieval

### DIFF
--- a/aws/resolve_customer/resolve_customer/app.py
+++ b/aws/resolve_customer/resolve_customer/app.py
@@ -120,7 +120,7 @@ def process_event(
             'marketplaceIdentifier': 'AWS',
             'marketplaceAccountId': customer.get_account_id(),
             'customerIdentifier': customer.get_id(),
-            "productCode": entitlements.get_toplevel_product_code(),
+            "productCode": customer.get_product_code(),
             'entitlements': entitlements.get_entitlements()
         }
     }

--- a/aws/resolve_customer/resolve_customer/entitlements.py
+++ b/aws/resolve_customer/resolve_customer/entitlements.py
@@ -82,14 +82,6 @@ class AWSCustomerEntitlement:
             )
             log_error(self.error)
 
-    def get_toplevel_product_code(self) -> str:
-        toplevel_product = ''
-        if self.entitlements:
-            entitlements = self.entitlements.get('Entitlements')
-            if entitlements:
-                toplevel_product = entitlements[0].get('ProductCode')
-        return toplevel_product
-
     def get_entitlements(self) -> List[dict]:
         result_entitlements: List = []
         if self.entitlements:

--- a/aws/resolve_customer/test/unit/app_test.py
+++ b/aws/resolve_customer/test/unit/app_test.py
@@ -93,7 +93,7 @@ class TestApp:
                 'marketplaceIdentifier': 'AWS',
                 'marketplaceAccountId': customer.get_account_id.return_value,
                 'customerIdentifier': customer.get_id.return_value,
-                'productCode': entitlements.get_toplevel_product_code.return_value,
+                'productCode': customer.get_product_code.return_value,
                 'entitlements': entitlements.get_entitlements.return_value
             }
         }

--- a/aws/resolve_customer/test/unit/entitlements_test.py
+++ b/aws/resolve_customer/test/unit/entitlements_test.py
@@ -120,6 +120,3 @@ class TestAWSCustomerEntitlement:
                 }
             }
         ]
-
-    def test_get_toplevel_product_code(self):
-        assert self.entitlements.get_toplevel_product_code() == 'some'


### PR DESCRIPTION
The product code was taken from the first entitlement list entry. This is wrong because there could be a product code without any entitlements. Thus the product code has to be taken from the response of the resolve customer API and not from the response of the entitlements. This Fixes #28