### PR TITLE
Subscription notifications

### DIFF
--- a/aws/resolve_customer/resolve_customer/entitlements.py
+++ b/aws/resolve_customer/resolve_customer/entitlements.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
+import logging
 import boto3
 from botocore.exceptions import ClientError
 from resolve_customer.defaults import Defaults
@@ -25,6 +26,9 @@ from resolve_customer.error import (
 from typing import (
     List, Dict
 )
+
+logger = logging.getLogger('marketplace_entitlement')
+logger.setLevel('INFO')
 
 
 class AWSCustomerEntitlement:
@@ -38,6 +42,11 @@ class AWSCustomerEntitlement:
         config = Defaults.get_assume_role_config()
         role: Dict[str, Dict[str, str]] = config.get('role') or {}
         if customer_id and product_code and role:
+            logger.info(
+                'requesting entitlements for customer {} and product {}'.format(
+                    customer_id, product_code
+                )
+            )
             for region in sorted(role.keys()):
                 try:
                     assume_role = AWSAssumeRole(

--- a/aws/sqs_event_manager/sqs_event_manager/message.py
+++ b/aws/sqs_event_manager/sqs_event_manager/message.py
@@ -50,6 +50,14 @@ class AWSSNSMessage:
         return self.get_sns_content().get('action') or ''
 
     @property
+    def offer_id(self) -> str:
+        return self.get_sns_content().get('offer-identifier') or ''
+
+    @property
+    def free_trial_term_present(self) -> str:
+        return self.get_sns_content().get('isFreeTrialTermPresent') or 'false'
+
+    @property
     def event_source_arn(self) -> str:
         return self.__get('eventSourceARN')
 

--- a/aws/sqs_event_manager/test/data/sqs_event_manager.yml
+++ b/aws/sqs_event_manager/test/data/sqs_event_manager.yml
@@ -1,2 +1,5 @@
 entitlement_change_url: https://inform-me-of-changes.com
+subscribe_success_url: https://inform-me-of-changes.com
+unsubscribe_success_url: https://inform-me-of-changes.com
+subscribe_fail_url: https://inform-me-of-changes.com
 auth_token: some

--- a/aws/sqs_event_manager/test/unit/defaults_test.py
+++ b/aws/sqs_event_manager/test/unit/defaults_test.py
@@ -5,5 +5,8 @@ class TestDefaults:
     def test_get_sqs_event_manager_config(self):
         assert Defaults.get_sqs_event_manager_config('../data/sqs_event_manager.yml') == {
             'entitlement_change_url': 'https://inform-me-of-changes.com',
+            'subscribe_success_url': 'https://inform-me-of-changes.com',
+            'unsubscribe_success_url': 'https://inform-me-of-changes.com',
+            'subscribe_fail_url': 'https://inform-me-of-changes.com',
             'auth_token': 'some'
         }

--- a/aws/sqs_event_manager/test/unit/message_test.py
+++ b/aws/sqs_event_manager/test/unit/message_test.py
@@ -9,7 +9,7 @@ class TestAWSSNSMessage:
         self._caplog = caplog
 
     def setup_method(self, cls):
-        record = {
+        record_entitlement = {
             'messageId': 'c7b2c992-4f07-478e-bfb8-f577e8310550',
             'receiptHandle': 'AQEBZ...',
             'body': '{\
@@ -38,7 +38,37 @@ class TestAWSSNSMessage:
             'eventSourceARN': 'arn:aws:sqs:eu-central-1:12345:ms-testing.fifo',
             'awsRegion': 'eu-central-1'
         }
-        self.message = AWSSNSMessage(record)
+        record_maintenance = {
+            'messageId': 'c7b2c992-4f07-478e-bfb8-f577e8310550',
+            'receiptHandle': 'AQEBZ...',
+            'body': '{\
+                "Type": "Notification", \
+                "MessageId": "123", \
+                "TopicArn": "arn:aws:sns:us-east-1:XXX:aws-mp-entitlement-notification-XXX", \
+                "Message" : "{\\n    \\"action\\": \\"subscribe-success\\",\\n    \\"customer-identifier\\": \\" abc123\\",\\n    \\"product-code\\": \\"7hn1uo40wt6psy10ovxyh4zzn\\", \\"offer-identifier\\": \\"offer-abcexample123\\", \\"isFreeTrialTermPresent\\": \\"false\\"\\n}",\n\
+                "Timestamp": "2025-01-15 16:31:50", \
+                "SignatureVersion": "1", \
+                "Signature": "abc123", \
+                "SigningCertURL": "string", \
+                "UnsubscribeURL": "string"\
+            }',
+            'attributes': {
+                'ApproximateReceiveCount': '1',
+                'SentTimestamp': '1738513550582',
+                'SequenceNumber': '18891803542658543872',
+                'MessageGroupId': '586474de88e09',
+                'SenderId': 'AIDA3ZKWXZJCWPK4AZP3G',
+                'MessageDeduplicationId': 'f78f3e796ac0abf15635b400b459bed17fb11608ae77cc95f6f850b165ef2faa',
+                'ApproximateFirstReceiveTimestamp': '1738513550582'
+            },
+            'messageAttributes': {},
+            'md5OfBody': '3f1b30bf45ba94b6a1cee5f9db39f60a',
+            'eventSource': 'aws:sqs',
+            'eventSourceARN': 'arn:aws:sqs:eu-central-1:12345:ms-testing.fifo',
+            'awsRegion': 'eu-central-1'
+        }
+        self.message = AWSSNSMessage(record_entitlement)
+        self.maintenance = AWSSNSMessage(record_maintenance)
 
     def test_get_message_id(self):
         assert self.message.message_id == 'c7b2c992-4f07-478e-bfb8-f577e8310550'
@@ -57,3 +87,9 @@ class TestAWSSNSMessage:
 
     def test_get_action(self):
         assert self.message.action == 'entitlement-updated'
+
+    def test_get_offer_id(self):
+        assert self.maintenance.offer_id == 'offer-abcexample123'
+
+    def test_get_free_trial_term_present(self):
+        assert self.maintenance.free_trial_term_present == 'false'


### PR DESCRIPTION
Add support for subscription events
    
Add support for the following subscription events in the  sqs event manager:
    
* subscribe-success
* unsubscribe-pending
* unsubscribe-success
* subscribe-fail
    
Except for the unsubscribe-pending event a POST request to a configurable endpoint is sent which has the following  request body.
    
```
request_data = {
    "customerIdentifier": "string",
    "marketplaceIdentifier": "AWS",
    "productCode": "string",
    "entitlements": AWSCustomerEntitlement::get_entitlements(): List
    "offerIdentifier": "string",
    "isFreeTrialTermPresent": "true|false"
}
```