### PR TITLE
Fix sqs manager POST request

### DIFF
--- a/aws/sqs_event_manager/sqs_event_manager/app.py
+++ b/aws/sqs_event_manager/sqs_event_manager/app.py
@@ -261,7 +261,7 @@ def send_to(
         headers['Authorization'] = f'Bearer {auth_token}'
     logger.info(f'Sending POST data to {endpoint_url}: {request_data}')
     http_post_response = requests.post(
-        endpoint_url, data=request_data, headers=headers
+        endpoint_url, json=request_data, headers=headers
     )
     http_post_response.raise_for_status()
     return {

--- a/aws/sqs_event_manager/test/unit/app_test.py
+++ b/aws/sqs_event_manager/test/unit/app_test.py
@@ -175,7 +175,7 @@ class TestApp:
         }
         mock_requests.post.assert_called_once_with(
             'https://inform-me-of-changes.com',
-            data={
+            json={
                 'customerIdentifier': 'abc123',
                 'marketplaceIdentifier': 'AWS',
                 'productCode': '7hn1uo40wt6psy10ovxyh4zzn',


### PR DESCRIPTION
The post request sent data=Dict which results in an URL encoded string like b'aaa&bbb' but the interface receiving the data expects proper json. This commit fixes it.