### PR TITLE
Improve error reporting for sqs event manager

### DIFF
--- a/aws/sqs_event_manager/sqs_event_manager/app.py
+++ b/aws/sqs_event_manager/sqs_event_manager/app.py
@@ -263,9 +263,10 @@ def send_to(
     http_post_response = requests.post(
         endpoint_url, json=request_data, headers=headers
     )
-    if http_post_response.status_code != 200:
+    status_code = http_post_response.status_code
+    if status_code != 200:
         result = {
-            'status': f'Event report failed with: {http_post_response.text}',
+            'status': f'Event report failed with: {status_code}:{http_post_response.text or "no response text"}',
             'error': True
         }
         logger.error(result['status'])

--- a/aws/sqs_event_manager/test/unit/app_test.py
+++ b/aws/sqs_event_manager/test/unit/app_test.py
@@ -160,7 +160,7 @@ class TestApp:
         mock_AWSCustomerEntitlement, mock_requests
     ):
         response = Mock()
-        response.status_code = 500
+        response.status_code = 404
         response.text = 'some error'
         mock_requests.post.return_value = response
         record = self.record
@@ -171,7 +171,13 @@ class TestApp:
         assert process_message(record) == {
             'error': True,
             'itemIdentifier': 'c7b2c992-4f07-478e-bfb8-f577e8310550',
-            'status': 'Event report failed with: some error'
+            'status': 'Event report failed with: 404:some error'
+        }
+        response.text = ''
+        assert process_message(record) == {
+            'error': True,
+            'itemIdentifier': 'c7b2c992-4f07-478e-bfb8-f577e8310550',
+            'status': 'Event report failed with: 404:no response text'
         }
 
     @patch('sqs_event_manager.app.requests')


### PR DESCRIPTION
If an event appears we are creating a POST request against a configured endpoint. This commit includes the HTTP status code to the error message in case of an error (!= 200). In addition the reported response text depends on the endpoint implementation. It can happen that the endpoint does not include any message, in this case we replace the information with a "no response text" provided such that we know the endpoint has an issue but no further information was provided.