### PR TITLE
Improve error message for InvalidTokenException

### DIFF
--- a/aws/resolve_customer/resolve_customer/error.py
+++ b/aws/resolve_customer/resolve_customer/error.py
@@ -57,5 +57,19 @@ def classify_error(
     return error
 
 
+def error_code_matches(error: Dict, aws_code: str) -> bool:
+    status = True if error['Error']['Code'] == aws_code else False
+    return status
+
+
+def set_message(error: Dict, message: str) -> Dict:
+    error['Error']['Message'] = message
+    return error
+
+
+def get_message(error: Dict) -> str:
+    return error['Error']['Message']
+
+
 def log_error(error: Dict) -> None:
     logger.error(error['Error']['Message'])


### PR DESCRIPTION
In case an invalid token is provided, it's good to see this token to be part of the logging information. Otherwise there is no chance to identify why the token was invalid. As the AWS API classified it as invalid, there is no security impact on logging this information.